### PR TITLE
fix: use sync kafka producer

### DIFF
--- a/.env.override
+++ b/.env.override
@@ -1,7 +1,7 @@
 # DO NOT PUSH CHANGES OF THIS FILE TO opentelemetry/opentelemetry-demo
 # PLACE YOUR .env ENVIRONMENT VARIABLES OVERRIDES IN THIS FILE
 
-IMAGE_NAME=europe-docker.pkg.dev/dynatrace-demoability/docker/astroshop-rds-and-payment-merge
+IMAGE_NAME=europe-docker.pkg.dev/dynatrace-demoability/docker/astroshop
 DEMO_VERSION=2.0.2
 
 # CART_DOCKERFILE=./dynatrace/Dockerfile.cart

--- a/src/checkout/kafka/producer.go
+++ b/src/checkout/kafka/producer.go
@@ -22,8 +22,6 @@ func CreateClient(brokers []string, log *logrus.Logger) (sarama.Client, error) {
 	// This setting is to prevent that issue from manifesting itself, but may swallow failed messages.
 	config.Producer.RequiredAcks = sarama.NoResponse
 	config.Version = ProtocolVersion
-	// So we can know the partition and offset of messages.
-	config.Producer.Return.Successes = true
 
 	client, err := sarama.NewClient(brokers, config)
 	if err != nil {


### PR DESCRIPTION
# Changes

Whenever kafka would get restarted the checkout service would start responding really slowly, ~1min. Changing the producer to sync fixes this issue